### PR TITLE
Fix lychee root-relative link resolution

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Run lychee link checker
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config .lychee.toml "dist/**/*.html"
+          args: --config .lychee.toml --root-dir "${{ github.workspace }}/dist" "dist/**/*.html"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "eleventy --serve",
     "build": "npm run clean && eleventy",
     "build:ci": "npm run build",
-    "check:links": "lychee --config .lychee.toml dist/**/*.html",
+    "check:links": "lychee --config .lychee.toml --root-dir \"$PWD/dist\" dist/**/*.html",
     "check:assets": "node scripts/check-assets.mjs",
     "check:lighthouse": "lhci autorun --config=.lighthouserc.json"
   },


### PR DESCRIPTION
### Motivation
- The lychee link checker could not resolve root-relative URLs (for example `/styles/main.css` and `/directory/`) when scanning generated `dist/**/*.html`, causing false positives in link checks.
- The local `check:links` script and the GitHub Actions `link-check` workflow needed to be aligned so Lychee resolves links the same way in CI and local checks.

### Description
- Add `--root-dir "$PWD/dist"` to the `check:links` script in `package.json` so Lychee can resolve root-relative links for local runs.
- Add `--root-dir "${{ github.workspace }}/dist"` to the `args` passed to `lycheeverse/lychee-action@v2` in `.github/workflows/link-check.yml` so CI runs use the repository `dist` folder as Lychee's root.

### Testing
- Ran `npm run build`, which completed successfully and produced the `dist/` output files.
- Ran `npm run check:links` locally, which could not complete because the `lychee` binary is not installed in this environment (link check therefore could not be fully verified locally).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb14253cc8332b466ba4d2f49230a)